### PR TITLE
Ensure we use ECS credentials for AWS calls, get correct IP

### DIFF
--- a/php/rts/list_rts.php
+++ b/php/rts/list_rts.php
@@ -37,7 +37,7 @@ function list_rts()
       'credentials' => $credentials,
     ));
     $ec2Client = new Ec2Client([
-      'region' => 'us-east-1',
+      'region'  => $config->{'AB'}->{'RTS_FINDER'}->{'ECS_REGION'}->{'VALUE'},
       'version' => '2016-11-15',
       'credentials' => $credentials,
     ]);

--- a/php/rts/list_rts.php
+++ b/php/rts/list_rts.php
@@ -60,7 +60,7 @@ function list_rts()
     foreach ($result['tasks'] as $task) {
       // Lookup the container instance for this task
       $containerInstance = $ecsClient->describeContainerInstances([
-        'cluster' => 'apps',
+        'cluster' => $config->{'AB'}->{'RTS_FINDER'}->{'ECS_CLUSTER'}->{'VALUE'},
         'containerInstances' => [$task['containerInstanceArn']],
       ]);
 


### PR DESCRIPTION
In #168 I added initial ECS discovery code, however it didn't work for two reasons.

1. [The PHP SDK doesn't include the ECS credential source by default](https://docs.aws.amazon.com/sdk-for-php/v3/developer-guide/guide_credentials_provider.html#chaining-providers), so we couldn't get any credentials on the deployed instance.

2. I trusted the `bindIP` result, which ended up being `0.0.0.0`.  So, now we dereference the EC2 ID and use the private IP of that instance.